### PR TITLE
Add WKAppBundleIdentifier to watch widget

### DIFF
--- a/CaloriesWidget/Info.plist
+++ b/CaloriesWidget/Info.plist
@@ -4,14 +4,19 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>kalorie</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
-	<key>UIDeviceFamily</key>
-	<array>
-		<integer>4</integer>
+        <key>NSExtension</key>
+        <dict>
+                <key>NSExtensionAttributes</key>
+                <dict>
+                        <key>WKAppBundleIdentifier</key>
+                        <string>bartoszrychlicki.com.kcal-watch.watchkitapp</string>
+                </dict>
+                <key>NSExtensionPointIdentifier</key>
+                <string>com.apple.widgetkit-extension</string>
+        </dict>
+        <key>UIDeviceFamily</key>
+        <array>
+                <integer>4</integer>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- connect the watchOS widget extension to the main Watch App

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880123b26e08323a5bccf252282f05f