### PR TITLE
Fix missing watch widget principal class

### DIFF
--- a/CaloriesWidget/Info.plist
+++ b/CaloriesWidget/Info.plist
@@ -6,9 +6,11 @@
 	<string>kalorie</string>
 	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).CaloriesWidget</string>
+        </dict>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>4</integer>

--- a/kcal-watch.xcodeproj/project.pbxproj
+++ b/kcal-watch.xcodeproj/project.pbxproj
@@ -747,8 +747,9 @@
 				DEVELOPMENT_TEAM = YCJHK26WUR;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CaloriesWidget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = CaloriesWidget;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+                               INFOPLIST_KEY_CFBundleDisplayName = CaloriesWidget;
+                               INFOPLIST_KEY_NSExtensionPrincipalClass = "$(PRODUCT_MODULE_NAME).CaloriesWidget";
+                               INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -776,9 +777,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YCJHK26WUR;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = CaloriesWidget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = CaloriesWidget;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+                               INFOPLIST_FILE = CaloriesWidget/Info.plist;
+                               INFOPLIST_KEY_CFBundleDisplayName = CaloriesWidget;
+                               INFOPLIST_KEY_NSExtensionPrincipalClass = "$(PRODUCT_MODULE_NAME).CaloriesWidget";
+                               INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- specify `NSExtensionPrincipalClass` for the watch widget
- include the same value in build settings

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880123b26e08323a5bccf252282f05f